### PR TITLE
Fix assert issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pilot_usdm.json
 usdm2xl.py
 usdm2xl_jsonata.py
 cProfile_results/
+results.txt
 
 # Editors
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Custom Local
+*.xlsx
+cProfile.txt
+compare_cprofile.py
+output*.txt
+pilot_usdm.json
+usdm2xl.py
+usdm2xl_jsonata.py
+cProfile_results/
+
 # Editors
 .vscode/
 .idea/

--- a/cdisc_rules_engine/services/data_services/usdm_data_service.py
+++ b/cdisc_rules_engine/services/data_services/usdm_data_service.py
@@ -344,12 +344,14 @@ class USDMDataService(BaseDataService):
         if isinstance(mapped_entity, str):
             return mapped_entity
         else:
-            closest_non_list_ancestor = USDMDataService.__get_closest_non_list_ancestor(parent)
+            closest_non_list_ancestor = USDMDataService.__get_closest_non_list_ancestor(
+                parent
+            )
             return mapped_entity.get(
                 self.__get_entity_name(
                     closest_non_list_ancestor.value,
                     USDMDataService.__get_parent(closest_non_list_ancestor),
-                    _depth=_depth+1
+                    _depth=_depth + 1,
                 ),
                 api_type,
             )

--- a/cdisc_rules_engine/services/data_services/usdm_data_service.py
+++ b/cdisc_rules_engine/services/data_services/usdm_data_service.py
@@ -224,7 +224,6 @@ class USDMDataService(BaseDataService):
             )
             datasets.append(dataset_metadata)
         # Print dataset names for debugging
-        # print("Returned dataset names:", [d.name for d in datasets])
         return datasets
 
     def to_parquet(self, file_path: str) -> str:

--- a/cdisc_rules_engine/services/data_services/usdm_data_service.py
+++ b/cdisc_rules_engine/services/data_services/usdm_data_service.py
@@ -327,7 +327,10 @@ class USDMDataService(BaseDataService):
         ]
         return self._reader_factory.dataset_implementation.from_records(records)
 
-    def __get_entity_name(self, value, parent: any):
+    def __get_entity_name(self, value, parent: any, _depth=0):
+        # Recursion guard to prevent infinite recursion
+        if _depth > 25:
+            return "UnknownEntity"
         if type(value) is dict:
             api_type = (
                 value.get("instanceType")
@@ -341,13 +344,12 @@ class USDMDataService(BaseDataService):
         if isinstance(mapped_entity, str):
             return mapped_entity
         else:
-            closest_non_list_ancestor = USDMDataService.__get_closest_non_list_ancestor(
-                parent
-            )
+            closest_non_list_ancestor = USDMDataService.__get_closest_non_list_ancestor(parent)
             return mapped_entity.get(
                 self.__get_entity_name(
                     closest_non_list_ancestor.value,
                     USDMDataService.__get_parent(closest_non_list_ancestor),
+                    _depth=_depth+1
                 ),
                 api_type,
             )


### PR DESCRIPTION
Removed to make include counting of null datasets.
if entity == "null":
    continue

parent_rel column now contains the immediate parent attribute name and not the full path

parent_entity and parent_id are taken from the parent object (the object containing the current instance), not from the current node.

